### PR TITLE
#168948387 Fix response when user want to edit article

### DIFF
--- a/server/controllers/articles.js
+++ b/server/controllers/articles.js
@@ -132,18 +132,15 @@ const articles = {
       });
     }
 
-    const { value, error } = helper.joiArticleSchema(body);
-
-    if (error) {
-      const errorMessage = error.details[0].message;
+    if (!body.title && !body.article) {
       return res.status(400).json({
         status: 400,
-        error: errorMessage,
+        error: 'You must provide updted article or title',
       });
     }
 
-    matchArticle.title = value.title || matchArticle.title;
-    matchArticle.article = value.article || matchArticle.article;
+    matchArticle.title = body.title || matchArticle.title;
+    matchArticle.article = body.article || matchArticle.article;
 
     res.status(200).json({
       status: 200,


### PR DESCRIPTION
#### What does this PR do?
fix the response given when a user wants to edit an article.
#### Description of Task to be completed?
- when a user is editing an article, it is not required to put all elements, given only title or article then specified article can be edited
#### How should this be manually tested?
- in your terminal or command line:
```
git clone https://github.com/elvisiraguha/Teamwork.git
cd Teamwork
git checkout bg-fix-article-edit-#168948387
npm install
npm start
```
- use postman with PATCH method at <localhost:3000/api/v1/articles/> try it with an empty body and try it again with title only or article only.
#### What are the relevant pivotal tracker stories?
[#168948387](https://www.pivotaltracker.com/story/show/168948387)
#### Screenshots (if appropriate)
![editingFailed](https://user-images.githubusercontent.com/34744026/66200902-56fca880-e6a2-11e9-84ab-40961fb6c127.png)
![edited](https://user-images.githubusercontent.com/34744026/66200913-5d8b2000-e6a2-11e9-96e8-d9f04b9ac517.png)

